### PR TITLE
Use devtool and sourceMap flag from webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,6 @@ The result is:
 
 * `url(/image.png)` => `require("./image.png")`
 
-### SourceMaps
-
-To include SourceMaps set the `sourceMap` query param.
-
-`require("css-loader?sourceMap!./file.css")`
-
-I. e. the extract-text-webpack-plugin can handle them.
-
 ### importing and chained loaders
 
 The query parameter `importLoaders` allow to configure which loaders should be applied to `@import`ed resources.

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function(content, map) {
 		}
 		return "\"+require(" + JSON.stringify(loaderUtils.urlToRequest(url, root)) + ")+\"";
 	});
-	if(query.sourceMap && !minimize) {
+	if(this.sourceMap && !minimize) {
 		var cssRequest = loaderUtils.getRemainingRequest(this);
 		var request = loaderUtils.getCurrentRequest(this);
 		if(!map) {


### PR DESCRIPTION
Instead of needing to apply the sourceMap query parameter generate if a
devtool option is specified in the webpack config.