### PR TITLE
Update Clean CSS to a less buggy version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "css loader module for webpack",
   "dependencies": {
-    "clean-css": "^3.1.9",
+    "clean-css": "^3.2.3",
     "fastparse": "^1.0.0",
     "loader-utils": "~0.2.2",
     "source-list-map": "^0.1.4"


### PR DESCRIPTION
Heyo, `clean-css` has had a few pretty awesome bugfixes recently (specifically, `calc` is being munged in 3.1). Just a quick update to the dependency.