### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,5 @@
     "type": "git",
     "url": "git@github.com:webpack/css-loader.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license

I'm going through our dependencies spitting out warnings on install, that's the reason for these :smile:  