### PR TITLE
Use title case for CSS Module in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Note: For prerendering with extract-text-webpack-plugin you should use `css-load
 
 (experimental)
 
-The query parameter `module` enables **CSS module** mode. (`css-loader?module`)
+The query parameter `module` enables **CSS Module** mode. (`css-loader?module`)
 
 * Local scoped by default.
 * `url(...)` URLs behave like requests in modules:


### PR DESCRIPTION
I'm thinking we should standardise the casing as "CSS Module", although it's clearly up for debate.