### PR TITLE
Improved class and ID regex selector match.

### DIFF
--- a/lib/parseSource.js
+++ b/lib/parseSource.js
@@ -236,10 +236,10 @@ var parser = new Parser({
 			"(\\s+):global\\s+": enableGlobal,
 
 			// class
-			"(\\.)([A-Za-z_\\-0-9]+)": selectorMatch,
+			"(\\.)(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)": selectorMatch,
 
 			// id
-			"(#)([A-Za-z_\\-0-9]+)": selectorMatch,
+			"(#)(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)": selectorMatch,
 
 			// inside
 			"\\{": rulesStartMatch,

--- a/test/moduleTestCases/simple/expected.css
+++ b/test/moduleTestCases/simple/expected.css
@@ -6,3 +6,6 @@ a[href="#b.c"]._x_._y_ {
 	color: green;
 	font-size: 1.5pt;
 }
+@keyframes _z_ {
+  2.5% {color: green;}
+}

--- a/test/moduleTestCases/simple/source.css
+++ b/test/moduleTestCases/simple/source.css
@@ -6,3 +6,6 @@ a[href="#b.c"].x.y {
 	color: green;
 	font-size: 1.5pt;
 }
+@keyframes z {
+  2.5% {color: green;}
+}


### PR DESCRIPTION
This fixes the incorrect matching of floating point keyframe values as class names:

    @keyframes z {
      2.5% {color: green;}
    }

Previously, the "5" in "2.5%" would be matched as a class name.  This commit fixes that.
