### PR TITLE
Update cssnano to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "css loader module for webpack",
   "dependencies": {
     "css-selector-tokenizer": "^0.5.1",
-    "cssnano": "^1.4.2",
+    "cssnano": "^2.1.0",
     "loader-utils": "~0.2.2",
     "postcss": "^4.1.11",
     "postcss-modules-extract-imports": "0.0.5",


### PR DESCRIPTION
There is a bug in the version of `postcss-normalize-urls` used by cssnano 1.4.2 which causes it to mess up data URIs (e.g. inline fonts and images) by converting `//` to `/`. Updating to the latest cssnano resolves this issue.