### PR TITLE
Allow ISO 10646 characters U+00A0 and higher in local ident

### DIFF
--- a/lib/getLocalIdent.js
+++ b/lib/getLocalIdent.js
@@ -11,5 +11,5 @@ module.exports = function getLocalIdent(loaderContext, localIdentName, localName
 	options.context = loaderContext.options && typeof loaderContext.options.context === "string" ? loaderContext.options.context : loaderContext.context;
 	localIdentName = localIdentName.replace(/\[local\]/gi, localName);
 	var hash = loaderUtils.interpolateName(loaderContext, localIdentName, options);
-	return hash.replace(/[^a-zA-Z0-9\-_]/g, "-").replace(/^([^a-zA-Z_])/, "_$1");
+	return hash.replace(new RegExp("[^a-zA-Z0-9\\-_\u00A0-\uFFFF]", "g"), "-").replace(/^([^a-zA-Z_])/, "_$1");
 };


### PR DESCRIPTION
I am setting `localIdentName=[name]の[local]` and was surprised that the `の` has been changed into a hyphen.

In CSS, any characters above U+00A0 are allowed, [per the specification](http://www.w3.org/TR/CSS21/syndata.html#characters) (emphasis mine):

> In CSS, _identifiers_ (including element names, classes, and IDs in [selectors](http://www.w3.org/TR/CSS21/selector.html)) can contain only the characters [a-zA-Z0-9] __and ISO 10646 characters U+00A0 and higher__, plus the hyphen (-) and the underscore (_) […]