### PR TITLE
Added camelCase option

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,6 +4,7 @@
 */
 var path = require("path");
 var loaderUtils = require("loader-utils");
+var camelCase = require("lodash.camelcase");
 var processCss = require("./processCss");
 var getImportPrefix = require("./getImportPrefix");
 
@@ -14,6 +15,7 @@ module.exports = function(content, map) {
 	var query = loaderUtils.parseQuery(this.query);
 	var root = query.root;
 	var moduleMode = query.modules || query.module;
+	var camelCaseKeys = query.camelCase || query.camelcase;
 
 	if(map !== null && typeof map !== "string") {
 		map = JSON.stringify(map);
@@ -85,7 +87,8 @@ module.exports = function(content, map) {
 			exportJs = Object.keys(result.exports).map(function(key) {
 				var valueAsString = JSON.stringify(result.exports[key]);
 				valueAsString = valueAsString.replace(result.importItemRegExpG, importItemMatcher.bind(this));
-				return "\t" + JSON.stringify(key) + ": " + valueAsString;
+				var exportKey = camelCaseKeys ? camelCase(key) : key;
+				return "\t" + JSON.stringify(exportKey) + ": " + valueAsString;
 			}.bind(this)).join(",\n");
 			exportJs = "exports.locals = {\n" + exportJs + "\n};";
 		}

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -84,12 +84,16 @@ module.exports = function(content, map) {
 
 		var exportJs = "";
 		if(Object.keys(result.exports).length > 0) {
-			exportJs = Object.keys(result.exports).map(function(key) {
+			var boundImportItemMatcher = importItemMatcher.bind(this);
+			exportJs = Object.keys(result.exports).reduce(function(res, key) {
 				var valueAsString = JSON.stringify(result.exports[key]);
-				valueAsString = valueAsString.replace(result.importItemRegExpG, importItemMatcher.bind(this));
-				var exportKey = camelCaseKeys ? camelCase(key) : key;
-				return "\t" + JSON.stringify(exportKey) + ": " + valueAsString;
-			}.bind(this)).join(",\n");
+				valueAsString = valueAsString.replace(result.importItemRegExpG, boundImportItemMatcher);
+				res.push("\t" + JSON.stringify(key) + ": " + valueAsString);
+				if (camelCaseKeys) {
+					res.push("\t" + JSON.stringify(camelCase(key)) + ": " + valueAsString);
+				}
+				return res;
+			}, []).join(",\n");
 			exportJs = "exports.locals = {\n" + exportJs + "\n};";
 		}
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "cssnano": ">=2.6.1 <4",
     "loader-utils": "~0.2.2",
     "object-assign": "^4.0.1",
+    "lodash.camelcase": "^3.0.1",
     "postcss": "^5.0.6",
     "postcss-modules-extract-imports": "1.0.0-beta2",
     "postcss-modules-local-by-default": "1.0.0-beta1",

--- a/test/camelCaseTest.js
+++ b/test/camelCaseTest.js
@@ -1,0 +1,19 @@
+/*globals describe */
+
+var test = require("./helpers").test;
+
+describe("camelCase", function() {
+	var css = ".btn-info { color: blue; }";
+	var exports = {
+		with: [
+			[1, "._38r5hlPyrqKLodJwWOdM1k { color: blue; }", ""]
+		],
+		without: [
+			[1, "._38r5hlPyrqKLodJwWOdM1k { color: blue; }", ""]
+		]
+	};
+	exports.with.locals = {'btn-info': '_38r5hlPyrqKLodJwWOdM1k'};
+	exports.without.locals = {btnInfo: '_38r5hlPyrqKLodJwWOdM1k'};
+	test("with", css, exports.with, "?modules");
+	test("without", css, exports.without, "?modules&camelCase");
+});

--- a/test/camelCaseTest.js
+++ b/test/camelCaseTest.js
@@ -13,7 +13,7 @@ describe("camelCase", function() {
 		]
 	};
 	exports.with.locals = {'btn-info': '_38r5hlPyrqKLodJwWOdM1k'};
-	exports.without.locals = {btnInfo: '_38r5hlPyrqKLodJwWOdM1k'};
+	exports.without.locals = {btnInfo: '_38r5hlPyrqKLodJwWOdM1k', 'btn-info': '_38r5hlPyrqKLodJwWOdM1k'};
 	test("with", css, exports.with, "?modules");
 	test("without", css, exports.without, "?modules&camelCase");
 });


### PR DESCRIPTION
This patch helps developers use `css-modules` with external libraries, like bootstrap. Popular css frameworks use *kebab-case* (bootstrap, foundation), or maybe other, like *snake_case*. We can resolve this problem if would automatically convert them to *camelCase*.
```css
/* styles.css */
.btn-info {
  color: blue;
}
```
```js
// app.js
const styles = require('!css?modules&camelCase!./styles.css');

console.log(styles.btnInfo) // _38r5hlPyrqKLodJwWOdM1k
console.log(styles['btn-info']) // undefined
```