### PR TITLE
Fix confusing paths in source maps

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -97,10 +97,14 @@ module.exports = function(content, map) {
 			map = result.map;
 			if(map.sources) {
 				map.sources = map.sources.map(function(source) {
-					var p = path.relative(query.context || this.options.context, source).replace(/\\/g, "/");
-					if(p.indexOf("../") !== 0)
-						p = "./" + p;
-					return "/" + p;
+					// trim off everything until the last occurrence of context
+					// we don't need the loader stuff in CSS source map sources.
+					var context = query.context || this.options.context;
+					var i = source.lastIndexOf(context);
+					if (i > -1) {
+						source = source.slice(i + context.length);
+					}
+					return "/" + source;
 				}, this);
 				map.sourceRoot = "webpack://";
 			}


### PR DESCRIPTION
Since CSS source maps are presented differently in the browser, we don't need the loader stuff in CSS source map sources. What do you think?

Before fix, paths (with the sass-loader) looked like:
![Before](https://cloud.githubusercontent.com/assets/781746/10181855/927929e6-671d-11e5-9f9e-447720c270b2.jpg)

After fix, paths look like:
![After](https://cloud.githubusercontent.com/assets/781746/10181857/a1a57d16-671d-11e5-92e0-10c8e4f646a0.jpg)

Also fixes jtangelder/sass-loader#150 

