### PR TITLE
Add support for :ref pseudoselector for accessing imports

### DIFF
--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -111,6 +111,71 @@ var parserPlugin = postcss.plugin("css-loader-parser", function(options) {
 			}
 		}
 
+		function processSelectorNode(item) {
+			// Helper for walking selector nodes and transforming :ref into
+			// references to mangled classnames in other CSS modules
+			// See the comment below in the walkRules block
+			switch (item.type) {
+				case 'selectors':
+				case 'nested-pseudo-class':
+				case 'selector':
+					// Just descend into children for these things
+					item.nodes.forEach(processSelectorNode);
+					break;
+				case 'pseudo-class':
+					if (item.name === 'ref') {
+						// We found :ref(...)
+						// It has a selector inside it.
+						// Parse it as a selector and rewrite the name or id to an import.
+						var refSelectorList = Tokenizer.parse(item.content);
+						if (!refSelectorList) {
+							throw new Error('Not a valid selector inside :ref! ' + item.content);
+						}
+						if (refSelectorList.nodes.length !== 1) {
+							throw new Error('Selector inside :ref must have exactly one part! ' + item.content);
+						}
+						var refSelector = refSelectorList.nodes[0];
+						if (refSelector.nodes.length !== 1) {
+							throw new Error('Selector inside :ref must have exactly one part! ' + item.content);
+						}
+						var refSelectorElement = refSelector.nodes[0];
+						if (refSelectorElement.type !== 'class' && refSelectorElement.type !== 'id') {
+							throw new Error('Selector inside :ref must be an id or class! ' + item.content);
+						}
+						var importIndex = imports['$' + refSelectorElement.name];
+						if (typeof importIndex !== 'number') {
+							throw new Error('Could not find :ref ' + refSelectorElement.name);
+						}
+
+						// Rewrite item to be a class or id equivalent to what is inside :ref
+						item.type = refSelectorElement.type;
+						item.name = "___CSS_LOADER_IMPORT___" + importIndex + "___";
+						delete item.content;
+					}
+					break;
+			}
+		}
+
+		css.walkRules(function(rule){
+			// Transform all references of the type :ref(.classname|#id) into the actual
+			// mangled classname/id imported from another file.
+			// Turns something like this
+			// :import('otherfile.css') {
+			// 	classB: classB;
+			// }
+			// .file_classA_abcdefg > :ref(.classB) {
+			// 	...
+			// }
+			// ...into...
+			// .file_classA_abcdefg > .otherfile_classB_hijklmn {
+			// 	...
+			// }
+			var selectorParseTree = Tokenizer.parse(rule.selector);
+			// Mutates the nodes inside the selector parse tree.
+			processSelectorNode(selectorParseTree);
+			rule.selector = Tokenizer.stringify(selectorParseTree);
+		});
+
 		css.walkDecls(function(decl) {
 			var values = Tokenizer.parseValues(decl.value);
 			values.nodes.forEach(function(value) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,6 +57,9 @@ function runLoader(loader, input, map, addOptions, callback) {
 	loader.call(opt, input, map);
 }
 
+exports.getEvaluated = getEvaluated;
+exports.runLoader = runLoader;
+
 exports.test = function test(name, input, result, query, modules) {
 	it(name, function(done) {
 		runLoader(cssLoader, input, undefined, !query || typeof query === "string" ? {

--- a/test/importedModuleTest.js
+++ b/test/importedModuleTest.js
@@ -1,0 +1,66 @@
+var helpers = require('./helpers.js');
+var cssLoader = require('../index.js');
+
+describe('imported modules', function(){
+    var source = "" +
+        ':import("imported.css") {\n' +
+            'importedClassB: classB;\n' +
+        '}\n' +
+        '\n' +
+        '.classA > :ref(.importedClassB) {\n' +
+            'color: red;\n' +
+        '}\n';
+
+    var imported = '' +
+        '.classB {\n' +
+            'color: orange;\n' +
+        '}\n' +
+        '\n' +
+        ':export {\n' +
+            'classB: classB;\n' +
+        '}\n';
+
+    var expected = '' +
+        '.source_classA_ > .imported_classB_ {\n' +
+            'color: red;\n' +
+        '}\n';
+    var modules = {};
+
+    beforeEach(function(done){
+        helpers.runLoader(cssLoader, imported, undefined, {
+            query: "?module&sourceMap&localIdentName=[name]_[local]_",
+            resourcePath: './imported.css',
+        }, function(err, output) {
+            if (err) {
+                done(err);
+                return;
+            }
+
+            modules = {
+                'imported.css' : helpers.getEvaluated(output, modules),
+            }
+            done();
+        });
+    });
+
+    it('outputs the names prefixed by `imported`', function(done){
+        helpers.runLoader(cssLoader, source, undefined, {
+            query: "?module&sourceMap&localIdentName=[name]_[local]_",
+            resourcePath: './source.css',
+        }, function(err, output) {
+            if (err) {
+                done(err);
+                return;
+            }
+            var exports = helpers.getEvaluated(output, modules);
+            Array.isArray(exports).should.be.eql(true);
+            (exports.length).should.be.eql(2);
+            (exports[0].length >= 3).should.be.eql(true);
+            (exports[0][0]).should.be.eql(1);
+            (exports[0][2]).should.be.eql("");
+            (exports[1][1]).should.be.eql(expected);
+            (exports.locals.classA).should.be.eql('source_classA_');
+            done();
+        });
+    })
+});


### PR DESCRIPTION
When importing class names or ids with the `:imports` pseudoselector,
this commit allows you to use these class names in CSS selectors by
wrapping them in a `:ref` pseudoselector. For example, if you have a
file which exports a CSS class like this...

```css
/* imported.css */
.classA {
}

:export {
    classA: classA;
}
```

And import it into a CSS file like this...
```css
/* source.css */
:import("imported.css") {
    localClassA: classA;
}

:ref(.localClassA) > .classB {
}
```

Then that last selector will be compiled down to somthing like
```css
/* compiled.css */
._imported_classA > ._source_classB {
}
```
The CSS Modules discussion around this is here https://github.com/css-modules/css-modules/issues/102