### PR TITLE
Specify node engine minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.23.1",
   "author": "Tobias Koppers @sokra",
   "description": "css loader module for webpack",
+  "engines": {
+    "node": ">=0.12.0"
+  },
   "dependencies": {
     "css-selector-tokenizer": "^0.5.1",
     "cssnano": ">=2.6.1 <4",


### PR DESCRIPTION
Setting the minimum version of the node engine will make npm to warn or
complain, if node `engine-strict` config is set to true, whenever the
installation environment does not meet this requirement.

Background:

`css-loader` depends on `postcss` that uses native promises. Promises
where introduced in node version 0.12.0. So `css-loader`
*transitively inherits* this dependency.

Related to #144.