### PR TITLE
add documentation for camelCase query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,27 @@ You can also disable or enforce minification with the `minimize` query parameter
 
 `css-loader?-import` disables `@import` handling.
 
+### Camel case
+
+By default, the exported JSON keys mirror the class names. If you want to camelize class names (useful in Javascript), pass the query parameter `camelCase` to the loader.
+
+Example:
+
+`css-loader?camelCase`
+
+Usage:
+```css
+/* file.css */
+
+.class-name { /* ... */ }
+```
+
+```js
+// javascript
+
+require('file.css').className
+```
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)


### PR DESCRIPTION
Hi @sokra et al,

I was searching all around the internet trying to find a way to camelize the class names exported from css loader (in conjunction with css modules), when I found your commit adding the camelCase query. :clap: 

I was hoping to surface that information in the documentation.