### PR TITLE
Avoid name collision

### DIFF
--- a/lib/getLocalIdent.js
+++ b/lib/getLocalIdent.js
@@ -9,7 +9,7 @@ module.exports = function getLocalIdent(loaderContext, localIdentName, localName
 	if(!options.context)
 		options.context = loaderContext.options && typeof loaderContext.options.context === "string" ? loaderContext.options.context : loaderContext.context;
 	var request = path.relative(options.context, loaderContext.resourcePath);
-	options.content = options.hashPrefix + request + "+" + localName;
+	options.content = options.hashPrefix + request + "+" + localName + "+" + options.content;
 	localIdentName = localIdentName.replace(/\[local\]/gi, localName);
 	var hash = loaderUtils.interpolateName(loaderContext, localIdentName, options);
 	return hash.replace(new RegExp("[^a-zA-Z0-9\\-_\u00A0-\uFFFF]", "g"), "-").replace(/^([^a-zA-Z_])/, "_$1");

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -165,11 +165,12 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 		extractImports(),
 		modulesValues,
 		modulesScope({
-			generateScopedName: function(exportName) {
+			generateScopedName: function(exportName, requireString, content) {
 				return getLocalIdent(options.loaderContext, localIdentName, exportName, {
 					regExp: localIdentRegExp,
 					hashPrefix: query.hashPrefix || "",
-					context: context
+					context: context,
+					content: content
 				});
 			}
 		}),

--- a/test/camelCaseTest.js
+++ b/test/camelCaseTest.js
@@ -6,18 +6,18 @@ describe("camelCase", function() {
 	var css = ".btn-info_is-disabled { color: blue; }";
 	var exports = {
 		with: [
-			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; }", ""]
+			[1, "._3HmXvRDfbLlPvWusOyDJM8 { color: blue; }", ""]
 		],
 		without: [
-			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; }", ""]
+			[1, "._3HmXvRDfbLlPvWusOyDJM8 { color: blue; }", ""]
 		],
 		dashes: [
-			[1, "._1L-rnCOXCE_7H94L5XT4uB { color: blue; }", ""]
+			[1, "._3HmXvRDfbLlPvWusOyDJM8 { color: blue; }", ""]
 		]
 	};
-	exports.with.locals = {'btn-info_is-disabled': '_1L-rnCOXCE_7H94L5XT4uB'};
-	exports.without.locals = {btnInfoIsDisabled: '_1L-rnCOXCE_7H94L5XT4uB', 'btn-info_is-disabled': '_1L-rnCOXCE_7H94L5XT4uB'};
-	exports.dashes.locals = {btnInfo_isDisabled: '_1L-rnCOXCE_7H94L5XT4uB', 'btn-info_is-disabled': '_1L-rnCOXCE_7H94L5XT4uB'};
+	exports.with.locals = {'btn-info_is-disabled': '_3HmXvRDfbLlPvWusOyDJM8'};
+	exports.without.locals = {btnInfoIsDisabled: '_3HmXvRDfbLlPvWusOyDJM8', 'btn-info_is-disabled': '_3HmXvRDfbLlPvWusOyDJM8'};
+	exports.dashes.locals = {btnInfo_isDisabled: '_3HmXvRDfbLlPvWusOyDJM8', 'btn-info_is-disabled': '_3HmXvRDfbLlPvWusOyDJM8'};
 	test("with", css, exports.with, "?modules");
 	test("without", css, exports.without, "?modules&camelCase");
 	test("dashes", css, exports.dashes, "?modules&camelCase=dashes");

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -133,3 +133,39 @@ exports.testMinimize = function testMinimize(name, input, result, query, modules
 		});
 	});
 };
+
+exports.testSelectorIsDifferent =
+	function testContains(name, input1, input2, query, modules) {
+		var selectorRegexp = /^([^{]*){/;
+
+		it(name, function(done) {
+			runLoader(cssLoader, input1, undefined, {
+				query: query
+			}, function(err, output) {
+				if(err) return done(err);
+				var exports1 = getEvaluated(output, modules);
+
+				runLoader(cssLoader, input2, undefined, {
+					query: query
+				}, function(err, output) {
+					if(err) return done(err);
+					var exports2 = getEvaluated(output, modules);
+
+					Array.isArray(exports1).should.be.eql(true);
+					(exports1.length).should.be.eql(1);
+					Array.isArray(exports2).should.be.eql(true);
+					(exports2.length).should.be.eql(1);
+
+					var content1 = exports1[0][1];
+					var content2 = exports2[0][1];
+
+					var selector1 = selectorRegexp.exec(content1)[1];
+					var selector2 = selectorRegexp.exec(content2)[1];
+
+					(selector1).should.not.eql(selector2);
+
+					done();
+				});
+			});
+		});
+	};

--- a/test/localTest.js
+++ b/test/localTest.js
@@ -15,18 +15,18 @@ function testLocalMinimize(name, input, result, localsResult, query, modules) {
 
 describe("local", function() {
 	testLocal("locals-format", ":local(.test) { background: red; }", [
-		[1, ".test-2_pBx { background: red; }", ""]
+		[1, ".test-CRBG9 { background: red; }", ""]
 	], {
-		test: "test-2_pBx"
+		test: "test-CRBG9"
 	}, "?localIdentName=[local]-[hash:base64:5]");
 	testLocal("locals", ":local(.className) { background: red; }\n:local(#someId) { background: green; }\n" +
 		":local(.className .subClass) { color: green; }\n:local(#someId .subClass) { color: blue; }", [
-		[1, "._23J0282swY7bwvI2X4fHiV { background: red; }\n#_3vpqN0v_IxlO3TzQjbpB33 { background: green; }\n" +
-			"._23J0282swY7bwvI2X4fHiV ._1s1VsToXFz17cPAltMg7jz { color: green; }\n#_3vpqN0v_IxlO3TzQjbpB33 ._1s1VsToXFz17cPAltMg7jz { color: blue; }", ""]
+		[1, "._2UEI_i8RIy-UrVRaoBHhBk { background: red; }\n#_1ejdFqws16MG8Y8X3yDdXH { background: green; }\n" +
+			"._2UEI_i8RIy-UrVRaoBHhBk ._1auRgXL3-Be4hsuCNGjxeO { color: green; }\n#_1ejdFqws16MG8Y8X3yDdXH ._1auRgXL3-Be4hsuCNGjxeO { color: blue; }", ""]
 	], {
-		className: "_23J0282swY7bwvI2X4fHiV",
-		someId: "_3vpqN0v_IxlO3TzQjbpB33",
-		subClass: "_1s1VsToXFz17cPAltMg7jz"
+		className: "_2UEI_i8RIy-UrVRaoBHhBk",
+		someId: "_1ejdFqws16MG8Y8X3yDdXH",
+		subClass: "_1auRgXL3-Be4hsuCNGjxeO"
 	});
 	testLocalMinimize("minimized plus local", ":local(.localClass) { background: red; }\n:local .otherClass { background: red; }\n:local(.empty) { }", [
 		[1, "._localClass,._otherClass{background:red}", ""]
@@ -146,17 +146,17 @@ describe("local", function() {
 	});
 	testLocal("module mode", ".className { background: url(./file.png); }\n#someId { background: url('module/file.jpg'); }\n" +
 		".className .subClass { font-size: 5.5pt; }\n#someId .subClass { color: blue; }", [
-		[1, "._23J0282swY7bwvI2X4fHiV { background: url({./file.png}); }\n#_3vpqN0v_IxlO3TzQjbpB33 { background: url({module/file.jpg}); }\n" +
-			"._23J0282swY7bwvI2X4fHiV ._1s1VsToXFz17cPAltMg7jz { font-size: 5.5pt; }\n#_3vpqN0v_IxlO3TzQjbpB33 ._1s1VsToXFz17cPAltMg7jz { color: blue; }", ""]
+		[1, "._3AoOZnb2gi0Z1HrqmzpOdy { background: url({./file.png}); }\n#_-Q_-eYs4B4Vn2f8Zoo8qF { background: url({module/file.jpg}); }\n" +
+			"._3AoOZnb2gi0Z1HrqmzpOdy .MH3-hInT-U-s6n70upuJl { font-size: 5.5pt; }\n#_-Q_-eYs4B4Vn2f8Zoo8qF .MH3-hInT-U-s6n70upuJl { color: blue; }", ""]
 	], {
-		className: "_23J0282swY7bwvI2X4fHiV",
-		someId: "_3vpqN0v_IxlO3TzQjbpB33",
-		subClass: "_1s1VsToXFz17cPAltMg7jz"
+		className: "_3AoOZnb2gi0Z1HrqmzpOdy",
+		someId: "_-Q_-eYs4B4Vn2f8Zoo8qF",
+		subClass: "MH3-hInT-U-s6n70upuJl"
 	}, "?module");
 	testLocal("class name parsing", ".-a0-34a___f { color: red; }", [
-		[1, "._3ZMCqVa1XidxdqbX65hZ5D { color: red; }", ""]
+		[1, "._2jMTI13a5iSEevjgB3oOZA { color: red; }", ""]
 	], {
-		"-a0-34a___f": "_3ZMCqVa1XidxdqbX65hZ5D"
+		"-a0-34a___f": "_2jMTI13a5iSEevjgB3oOZA"
 	}, "?module");
 	testLocal("imported values in decl", ".className { color: IMPORTED_NAME; }\n" +
 		":import(\"./vars.css\") { IMPORTED_NAME: primary-color; }", [
@@ -171,9 +171,9 @@ describe("local", function() {
 		}
 	});
 	testLocal("issue-109", ".bar-1 { color: red; }", [
-		[1, ".file--bar-1--2JvfJ { color: red; }", ""]
+		[1, ".file--bar-1--2AaXD { color: red; }", ""]
 	], {
-		"bar-1": "file--bar-1--2JvfJ"
+		"bar-1": "file--bar-1--2AaXD"
 	}, "?modules&importLoaders=1&localIdentName=[name]--[local]--[hash:base64:5]");
 	testLocal("path naming", ".bar { color: red; }", [
 		[1, ".path-to--file--bar { color: red; }", ""]
@@ -198,8 +198,8 @@ describe("local", function() {
 		}
 	});
 	testLocal("hash prefix", ".bar { color: red; }", [
-		[1, ".bar--58a3b08b9195a6af0de7431eaf3427c7 { color: red; }", ""]
+		[1, ".bar--f888243db8b4f2cc740167e39622284b { color: red; }", ""]
 	], {
-		"bar": "bar--58a3b08b9195a6af0de7431eaf3427c7"
+		"bar": "bar--f888243db8b4f2cc740167e39622284b"
 	}, "?modules&localIdentName=[local]--[hash]&hashPrefix=x");
 });

--- a/test/moduleHashTestCases.js
+++ b/test/moduleHashTestCases.js
@@ -1,0 +1,29 @@
+/*globals describe */
+
+var test = require("./helpers").testSelectorIsDifferent;
+
+describe("module", function() {
+	test("Hash for different property value",
+		".foo { background-color: red; }",
+		".foo { background-color: blue; }",
+		"?module&sourceMap&localIdentName=_[local]_[hash]"
+	);
+
+	test("Hash for different property",
+		".foo { color: red; }",
+		".foo { background-color: red; }",
+		"?module&sourceMap&localIdentName=_[local]_[hash]"
+	);
+
+	test("Hash for different content",
+		".foo { color: red; }",
+		".foo { border: 1px solid #aaa; }",
+		"?module&sourceMap&localIdentName=_[local]_[hash]"
+	);
+
+	test("Hash for different selector",
+		".foo { color: red; }",
+		".bar { color: red; }",
+		"?module&sourceMap&localIdentName=_[local]_[hash]"
+	);
+});


### PR DESCRIPTION
When 2 files from different projects share the same relative file path AND
selector, the generated hash is the same.

This should not happen, as css-modules are designed to avoid collision.

This pull request add the file content to the hash generation seed, it seems to be the simplest way to do it.