### PR TITLE
Consistent format for syntax errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "node": ">=0.12.0"
   },
   "dependencies": {
+    "babel-code-frame": "^6.11.0",
     "css-selector-tokenizer": "^0.6.0",
     "cssnano": ">=2.6.1 <4",
     "loader-utils": "~0.2.2",
-    "object-assign": "^4.0.1",
     "lodash.camelcase": "^3.0.1",
+    "object-assign": "^4.0.1",
     "postcss": "^5.0.6",
     "postcss-modules-extract-imports": "^1.0.0",
     "postcss-modules-local-by-default": "^1.0.1",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -69,6 +69,23 @@ exports.test = function test(name, input, result, query, modules) {
 	});
 };
 
+exports.testError = function test(name, input, onError) {
+	it(name, function(done) {
+    runLoader(cssLoader, input, undefined, {}, function(err, output) {
+      if (!err) {
+        done(new Error('Expected error to be thrown'));
+      } else {
+        try {
+          onError(err);
+        } catch (error) {
+          return done(error);
+        }
+        done();
+      }
+		});
+	});
+};
+
 exports.testWithMap = function test(name, input, map, result, query, modules) {
 	it(name, function(done) {
 		runLoader(cssLoader, input, map, {

--- a/test/simpleTest.js
+++ b/test/simpleTest.js
@@ -1,6 +1,8 @@
 /*globals describe */
 
+var assert = require('assert');
 var test = require("./helpers").test;
+var testError = require("./helpers").testError;
 var testMinimize = require("./helpers").testMinimize;
 
 describe("simple", function() {
@@ -19,4 +21,15 @@ describe("simple", function() {
 	testMinimize("minimized simple", ".class { a: b c d; }", [
 		[1, ".class{a:b c d}", ""]
 	]);
+  testError("error formatting", ".some {\n invalid css;\n}", function(err) {
+    assert.equal(err.message, [
+      'Unknown word (2:2)',
+      '',
+      '  1 | .some {',
+      '> 2 |  invalid css;',
+      '    |  ^',
+      '  3 | }',
+      '',
+    ].join('\n'));
+  });
 });


### PR DESCRIPTION
I used babel-code-frame package formatting syntax errors code frames. That makes it consistent with Babel output which is I think very important as it makes it less cognitive efforts to recognize and process the error.

You can also see that there's no duplicated filename in error message as webpack already print module name.

Before:

<img width="888" alt="screenshot 2016-08-15 19 47 37" src="https://cloud.githubusercontent.com/assets/30594/17671724/24d6294c-6321-11e6-8d7a-a500f41381b4.png">

After:

<img width="299" alt="screenshot 2016-08-15 19 46 07" src="https://cloud.githubusercontent.com/assets/30594/17671683/f5bbbbc2-6320-11e6-8d28-511a14194d74.png">


See also:
* https://github.com/babel/babel-loader/pull/287
* https://github.com/postcss/postcss-loader/pull/87