### PR TITLE
The way I should specify minification options is "unpleasant"

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,24 @@ This may change in the future, when the module system (i. e. webpack) supports l
 
 By default the css-loader minimizes the css if specified by the module system.
 
-In some cases the minification is destructive to the css, so you can provide some options to it. cssnano is used for minification and you find a [list of options here](http://cssnano.co/options/). Just provide them as query parameter: i. e. `require("css-loader?-autoprefixer")` to disable removing of deprecated vendor prefixes.
+In some cases the minification is destructive to the css, so you can provide some options to it. cssnano is used for minification and you find a [list of options here](http://cssnano.co/options/). Just provide them as query parameter: i. e. `require("css-loader?-autoprefixer")` to disable removing of deprecated vendor prefixes. Or provide the path to the file with options by `minimizeConfigFile` query parameter:
+
+``` js
+// app/.cssnano.json
+{
+  "core": true
+}
+
+// app/webpack.config.js
+module.exports = {
+  ...,
+  module: {
+    loaders: [
+      { test: /\.css$/, loader: "css?minimizeConfigFile=.cssnano" }
+    ]
+  }
+};
+```
 
 You can also disable or enforce minification with the `minimize` query parameter.
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -27,6 +27,7 @@ module.exports = function(content, map) {
 		to: loaderUtils.getCurrentRequest(this),
 		query: query,
 		minimize: this.minimize,
+		minimizeConfigFile: this.minimizeConfigFile,
 		loaderContext: this
 	}, function(err, result) {
 		if(err) return callback(err);

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -8,6 +8,7 @@ var postcss = require("postcss");
 var loaderUtils = require("loader-utils");
 var assign = require("object-assign");
 var getLocalIdent = require("./getLocalIdent");
+var path = require('path');
 
 var localByDefault = require("postcss-modules-local-by-default");
 var extractImports = require("postcss-modules-extract-imports");
@@ -178,7 +179,12 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 	]);
 
 	if(minimize) {
-		var minimizeOptions = assign({}, query);
+		var minimizeOptions = {};
+		if (query.minimizeConfigFile) {
+			var minimizeOptionsFromFile = require(path.resolve(query.minimizeConfigFile));
+			assign(minimizeOptions, minimizeOptionsFromFile);
+		}
+		assign(minimizeOptions, query);
 		["zindex", "normalizeUrl", "discardUnused", "mergeIdents", "reduceIdents"].forEach(function(name) {
 			if(typeof minimizeOptions[name] === "undefined")
 				minimizeOptions[name] = false;


### PR DESCRIPTION
I will disfigure my configuration file if I try to specify many options for `cssnano`. Why not provide an option to parse the file with options?
