### PR TITLE
Prefix hashes with underscores based on CSS spec

### DIFF
--- a/lib/getLocalIdent.js
+++ b/lib/getLocalIdent.js
@@ -12,5 +12,5 @@ module.exports = function getLocalIdent(loaderContext, localIdentName, localName
 	options.content = options.hashPrefix + request + "+" + localName;
 	localIdentName = localIdentName.replace(/\[local\]/gi, localName);
 	var hash = loaderUtils.interpolateName(loaderContext, localIdentName, options);
-	return hash.replace(new RegExp("[^a-zA-Z0-9\\-_\u00A0-\uFFFF]", "g"), "-").replace(/^([^a-zA-Z_])/, "_$1");
+	return hash.replace(new RegExp("[^a-zA-Z0-9\\-_\u00A0-\uFFFF]", "g"), "-").replace(/^((-?[0-9])|--)/, "_$1");
 };

--- a/test/localTest.js
+++ b/test/localTest.js
@@ -202,4 +202,19 @@ describe("local", function() {
 	], {
 		"bar": "bar--58a3b08b9195a6af0de7431eaf3427c7"
 	}, "?modules&localIdentName=[local]--[hash]&hashPrefix=x");
+	testLocal("prefixes leading digit with underscore", ":local(.test) { background: red; }", [
+		[1, "._1test { background: red; }", ""]
+	], {
+		test: "_1test"
+	}, "?localIdentName=1[local]");
+	testLocal("prefixes leading hyphen + digit with underscore", ":local(.test) { background: red; }", [
+		[1, "._-1test { background: red; }", ""]
+	], {
+		test: "_-1test"
+	}, "?localIdentName=-1[local]");
+	testLocal("prefixes two leading hyphens with underscore", ":local(.test) { background: red; }", [
+		[1, "._--test { background: red; }", ""]
+	], {
+		test: "_--test"
+	}, "?localIdentName=--[local]");
 });


### PR DESCRIPTION
According to the CSS spec, "identifiers cannot start with a digit, two hyphens, or a hyphen followed by a digit" ([Source](https://www.w3.org/TR/CSS2/syndata.html#value-def-identifier))

The current regular expression doesn't quite follow the spec, leading to unnecessary prefixing. I noticed this when using the `[emoji]` placeholder in `localIdentName`. Every emoji was being prefixed with an underscore, despite [Glen Maddern's site](https://glenmaddern.com/) proving to the world that a single emoji is a valid class name.

Also, I noticed that this prefixing behaviour was currently untested, so I've added some test cases for the new regular expression to show how it works in practice.

cc @geelen