### PR TITLE
Pass `customInterpolateName` from query

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var path = require("path");
+var assign = require('object-assign');
 var loaderUtils = require("loader-utils");
 var processCss = require("./processCss");
 var getImportPrefix = require("./getImportPrefix");
@@ -12,7 +13,9 @@ var compileExports = require("./compile-exports");
 module.exports = function(content, map) {
 	if(this.cacheable) this.cacheable();
 	var callback = this.async();
-	var query = loaderUtils.parseQuery(this.query);
+	var globalOptions = this.options.css || {};
+	var loaderOptions = loaderUtils.parseQuery(this.query);
+	var query = assign({}, globalOptions, loaderOptions);
 	var root = query.root;
 	var moduleMode = query.modules || query.module;
 	var camelCaseKeys = query.camelCase || query.camelcase;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -3,7 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var path = require("path");
-var assign = require('object-assign');
+var assign = require("object-assign");
 var loaderUtils = require("loader-utils");
 var processCss = require("./processCss");
 var getImportPrefix = require("./getImportPrefix");

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -13,8 +13,9 @@ var compileExports = require("./compile-exports");
 module.exports = function(content, map) {
 	if(this.cacheable) this.cacheable();
 	var callback = this.async();
-	var globalOptions = this.options.css || {};
 	var loaderOptions = loaderUtils.parseQuery(this.query);
+	var configKey = loaderOptions.config || "cssLoader";
+	var globalOptions = this.options[configKey] || {};
 	var query = assign({}, globalOptions, loaderOptions);
 	var root = query.root;
 	var moduleMode = query.modules || query.module;

--- a/lib/localsLoader.js
+++ b/lib/localsLoader.js
@@ -6,12 +6,16 @@ var loaderUtils = require("loader-utils");
 var processCss = require("./processCss");
 var getImportPrefix = require("./getImportPrefix");
 var compileExports = require("./compile-exports");
+var assign = require("object-assign");
 
 
 module.exports = function(content) {
 	if(this.cacheable) this.cacheable();
 	var callback = this.async();
-	var query = loaderUtils.parseQuery(this.query);
+	var loaderOptions = loaderUtils.parseQuery(this.query);
+	var configKey = loaderOptions.config || "cssLoader";
+	var globalOptions = this.options[configKey] || {};
+	var query = assign({}, globalOptions, loaderOptions);
 	var moduleMode = query.modules || query.module;
 	var camelCaseKeys = query.camelCase || query.camelcase;
 

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -140,10 +140,9 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 	var forceMinimize = query.minimize;
 	var minimize = typeof forceMinimize !== "undefined" ? !!forceMinimize : options.minimize;
 
-	if (!options.loaderContext.options) {
-		options.loaderContext.options = {};
-	}
-	options.loaderContext.options.customInterpolateName = query.customInterpolateName;
+	options.loaderContext.options = assign({}, options.loaderContext.options, {
+		customInterpolateName: query.customInterpolateName
+	});
 
 	var parserOptions = {
 		root: root,

--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -140,6 +140,11 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 	var forceMinimize = query.minimize;
 	var minimize = typeof forceMinimize !== "undefined" ? !!forceMinimize : options.minimize;
 
+	if (!options.loaderContext.options) {
+		options.loaderContext.options = {};
+	}
+	options.loaderContext.options.customInterpolateName = query.customInterpolateName;
+
 	var parserOptions = {
 		root: root,
 		mode: options.mode,


### PR DESCRIPTION
It is based on top of #315 by @helloyou2012.

This PR allows to pass `customInterpolateName` function from webpack config to loaderUtils.interpolateName. It allows to generate classnames manually. It will solve #292. 

Webpack config:

``` js
let i = 0;

module.exports = {
  module: {
    loaders: [{
      test: /\.css$/,
      loader: 'style!css?modules&importLoaders=1&localIdentName=[name]__[local]'
    }]
  },
  cssLoader: {
    customInterpolateName: function() {
      i++;
      return '_' + i;
    }
  }
};
```

For this file structure:

```
first.css
  .title {}
  .text {}
second.css
  .title {}
```

returns

``` css
._1 {} /* first.css  → .title */
._2 {} /* first.css  → .text  */
._3 {} /* second.css → .title */
```
