### PR TITLE
Fix #340

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -98,7 +98,7 @@ module.exports = function(content, map) {
 			if(map.sources) {
 				map.sources = map.sources.map(function(source) {
 					source = source.split("!").pop();
-					var p = path.relative(query.context || this.options.context, source).replace(/\\/g, "/");
+					var p = path.relative(query.context || this.context, source).replace(/\\/g, "/");
 					if(p.indexOf("../") !== 0)
 						p = "./" + p;
 					return "/" + p;


### PR DESCRIPTION
this is a fix for #340.

The WebpackLoaderOptions plugin appears to overwrite `this.options`, causing `this.context.options` to be undefined and throwing `path should be a string` errors.