### PR TITLE
Add support for complex config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,36 @@ module.exports = {
 };
 ```
 
+## Advanced options
+
+If you need to pass [more advanced options](https://github.com/webpack/css-loader/pull/348), especially those which cannot be stringified, you can also define an `cssLoader`-property on your `webpack.config.js`:
+
+``` javascript
+module.exports = {
+  module: {
+    loaders: [{
+      test: /\.css$/,
+      loader: "style-loader!css-loader"
+    }]
+  },
+  cssLoader: {}
+};
+```
+
+If you need to define two different loader configs, you can also change the config's property name via `css?config=otherCssLoaderConfig`:
+
+``` javascript
+module.exports = {
+  module: {
+    loaders: [{
+      test: /\.css$/,
+      loader: "style-loader!css-loader?config=otherCssLoaderConfig"
+    }]
+  },
+  otherCssLoaderConfig: {}
+};
+```
+
 ### 'Root-relative' urls
 
 For urls that start with a `/`, the default behavior is to not translate them:

--- a/lib/getLoaderConfig.js
+++ b/lib/getLoaderConfig.js
@@ -1,0 +1,5 @@
+var loaderUtils = require("loader-utils");
+
+module.exports = function getLoaderConfig(loaderContext) {
+    return loaderUtils.getLoaderConfig(loaderContext, 'cssLoader') || {};
+};

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,12 +6,13 @@ var path = require("path");
 var loaderUtils = require("loader-utils");
 var processCss = require("./processCss");
 var getImportPrefix = require("./getImportPrefix");
+var getLoaderConfig = require("./getLoaderConfig");
 
 
 module.exports = function(content, map) {
 	if(this.cacheable) this.cacheable();
 	var callback = this.async();
-	var query = loaderUtils.parseQuery(this.query);
+	var query = getLoaderConfig(this);
 	var root = query.root;
 	var moduleMode = query.modules || query.module;
 


### PR DESCRIPTION
This PR adds ability to use use custom loader options:

``` js
{
    module: {
        loaders: [{
            test: /\.css$/,
            loaders: [
                'style',
                'css?config=customCssConfig'
            ]
        }]
    },
    customCssConfig: {}
}
```

Instead of #327, #315 I prefer to use recommended way to retrieve the loader config [`loader-utils#getloaderconfig`](https://github.com/webpack/loader-utils#getloaderconfig).

@sokra Could you please review this PR?
