### PR TITLE
Added the possibility of using -url and root options at the same time

### DIFF
--- a/lib/processCss.js
+++ b/lib/processCss.js
@@ -152,7 +152,7 @@ module.exports = function processCss(inputSource, inputMap, options, callback) {
 		localByDefault({
 			mode: options.mode,
 			rewriteUrl: function(global, url) {
-				if(parserOptions.url){
+				if(parserOptions.url || (!parserOptions.url && parserOptions.root)){
 					if(!loaderUtils.isUrlRequest(url, root)) {
 						return url;
 					}


### PR DESCRIPTION
I was trying to use -url and root together to be able to replace my assets paths without being resolved by webpack.
But these options wasn't working together, so I wasn't able to have my assets resolved by navigators when using sourceMaps (style-loader embed styles inside a blob file).
