### PR TITLE
Make -loader suffix consistent in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
 
 ``` javascript
-var css = require("css!./file.css");
+var css = require("css-loader!./file.css");
 // => returns css code from file.css, resolves imports and url(...)
 ```
 


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra @SpaceK33z 