### PR TITLE
Bump source-map-list to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postcss-modules-local-by-default": "^1.0.1",
     "postcss-modules-scope": "^1.0.0",
     "postcss-modules-values": "^1.1.0",
-    "source-list-map": "^0.1.4"
+    "source-list-map": "^0.1.7"
   },
   "devDependencies": {
     "codecov.io": "^0.1.2",


### PR DESCRIPTION
Per https://github.com/facebookincubator/create-react-app/pull/1101#issuecomment-264865954, we would like to make sure https://github.com/webpack/source-list-map/pull/3 ships to Webpack 1.x users without deleting `node_modules` and reinstalling.

Webpack core PR is in https://github.com/webpack/core/pull/30, this one is just for consistency and I don't care too much when this one gets released.